### PR TITLE
Fix repeat of visual LiveEasyAlign

### DIFF
--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -805,7 +805,9 @@ function! s:interactive(range, modes, n, d, opts, rules, vis, bvis)
   endwhile
   if s:live
     let copts = call('s:summarize', output.summarize)
+    let s:live = 0
     let g:easy_align_last_command = s:echon('', n, regx, d, copts, '')
+    let s:live = 1
   end
   return [mode, n, ch, opts, regx]
 endfunction


### PR DESCRIPTION
This fixes https://github.com/junegunn/vim-easy-align/issues/51. You could also substitute `EasyAlign` for `LiveEasyAlign` after the `echon`, or add an argument to `echon`, or put the `let s:live = 1` line afterwards in a `finally` block, or...
