### PR TITLE
add g:easy_align_nth to allow configuring default nth

### DIFF
--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -1050,7 +1050,7 @@ function! s:build_mode_sequence(expr, recur)
 endfunction
 
 function! s:process(range, mode, n, ch, opts, regexp, rules, bvis)
-  let [nth, recur] = s:parse_nth(a:n)
+  let [nth, recur] = s:parse_nth((empty(a:n) && exists('g:easy_align_nth')) ? g:easy_align_nth : a:n)
   let dict = s:build_dict(a:rules, a:ch, a:regexp, a:opts)
   let [mode_sequence, recur] = s:build_mode_sequence(
     \ get(dict, 'align', recur == 2 ? s:alternating_modes(a:mode) : a:mode),

--- a/test/interactive.vader
+++ b/test/interactive.vader
@@ -581,6 +581,120 @@ Do:
 Execute (g:easy_align_last_command should not be set if interrupted):
   Assert !exists('g:easy_align_last_command')
 
+Do (g:easy_align_nth is not set (work with default value 1)):
+  vip\<Enter>|
+
+Expect:
+  | Option| Type | Default | Description |
+  | --|--|--|--|
+  | threads | Fixnum | 1 | number of threads in the thread pool |
+  | queues |Fixnum | 1 | number of concurrent queues |
+  | queue_size | Fixnum | 1000 | size of each queue |
+  | interval | Numeric | 0 | dispatcher interval for batch processing |
+  | batch | Boolean | false | enables batch processing mode |
+  | batch_size | Fixnum | nil | number of maximum items to be assigned at once |
+  | logger | Logger | nil | logger instance for debug logs |
+
+Execute (set g:easy_align_nth):
+  let g:easy_align_nth = '2'
+
+Do (g:easy_align_nth is set as 2):
+  vip\<Enter>|
+
+Expect:
+  | Option     | Type | Default | Description |
+  |--          | --|--|--|
+  | threads    | Fixnum | 1 | number of threads in the thread pool |
+  |queues      | Fixnum | 1 | number of concurrent queues |
+  |queue_size  | Fixnum | 1000 | size of each queue |
+  |   interval | Numeric | 0 | dispatcher interval for batch processing |
+  |batch       | Boolean | false | enables batch processing mode |
+   |batch_size | Fixnum | nil | number of maximum items to be assigned at once |
+   |logger     | Logger | nil | logger instance for debug logs |
+
+Execute (unset g:easy_align_nth):
+  unlet g:easy_align_nth
+
+Execute (set g:easy_align_nth):
+  let g:easy_align_nth = '*'
+
+Do (g:easy_align_nth is set as *):
+  vip\<Enter>|
+
+Expect:
+  | Option     | Type    | Default | Description                                    |
+  | --         | --      | --      | --                                             |
+  | threads    | Fixnum  | 1       | number of threads in the thread pool           |
+  | queues     | Fixnum  | 1       | number of concurrent queues                    |
+  | queue_size | Fixnum  | 1000    | size of each queue                             |
+  | interval   | Numeric | 0       | dispatcher interval for batch processing       |
+  | batch      | Boolean | false   | enables batch processing mode                  |
+  | batch_size | Fixnum  | nil     | number of maximum items to be assigned at once |
+  | logger     | Logger  | nil     | logger instance for debug logs                 |
+
+Execute (unset g:easy_align_nth):
+  unlet g:easy_align_nth
+
+Execute (set g:easy_align_nth):
+  let g:easy_align_nth = '**'
+
+Do (g:easy_align_nth is set as **):
+  vip\<Enter>|
+
+Expect:
+  |     Option | Type    | Default | Description                                    |
+  |         -- | --      |      -- | --                                             |
+  |    threads | Fixnum  |       1 | number of threads in the thread pool           |
+  |     queues | Fixnum  |       1 | number of concurrent queues                    |
+  | queue_size | Fixnum  |    1000 | size of each queue                             |
+  |   interval | Numeric |       0 | dispatcher interval for batch processing       |
+  |      batch | Boolean |   false | enables batch processing mode                  |
+  | batch_size | Fixnum  |     nil | number of maximum items to be assigned at once |
+  |     logger | Logger  |     nil | logger instance for debug logs                 |
+
+Execute (unset g:easy_align_nth):
+  unlet g:easy_align_nth
+
+Execute (set g:easy_align_nth):
+  let g:easy_align_nth = '-'
+
+Do (g:easy_align_nth is set as -):
+  vip\<Enter>|
+
+Expect:
+  | Option| Type | Default | Description                                       |
+  |--|--|--|--                                                                 |
+  | threads | Fixnum | 1 | number of threads in the thread pool                |
+  |queues |Fixnum | 1 | number of concurrent queues                            |
+  |queue_size | Fixnum | 1000 | size of each queue                             |
+  |   interval | Numeric | 0 | dispatcher interval for batch processing        |
+  |batch | Boolean | false | enables batch processing mode                     |
+   |batch_size | Fixnum | nil | number of maximum items to be assigned at once |
+   |logger | Logger | nil | logger instance for debug logs                     |
+
+Execute (unset g:easy_align_nth):
+  unlet g:easy_align_nth
+
+Execute (set g:easy_align_nth):
+  let g:easy_align_nth = '-2'
+
+Do (g:easy_align_nth is set as -2):
+  vip\<Enter>|
+
+Expect:
+  | Option| Type | Default    | Description |
+  |--|--|--                   | --|
+  | threads | Fixnum | 1      | number of threads in the thread pool |
+  |queues |Fixnum | 1         | number of concurrent queues |
+  |queue_size | Fixnum | 1000 | size of each queue |
+  |   interval | Numeric | 0  | dispatcher interval for batch processing |
+  |batch | Boolean | false    | enables batch processing mode |
+   |batch_size | Fixnum | nil | number of maximum items to be assigned at once |
+   |logger | Logger | nil     | logger instance for debug logs |
+
+Execute (unset g:easy_align_nth):
+  unlet g:easy_align_nth
+
 ###########################################################
 
 Given (comma-separated items):


### PR DESCRIPTION
I'd like to use * as default nth instead of 1.
To realize this feature, I added g:easy_align_nth to allow configuring default nth.
Adding following line in your `.vimrc` allows you to configure it.
```
let g:easy_align_nth = '*'
```
If you don't set this variable, the default is the same as original value 1.