### PR TITLE
Allow 'easy-align.txt' to be listed in the LOCAL ADDITIONS section of help.txt

### DIFF
--- a/doc/easy_align.txt
+++ b/doc/easy_align.txt
@@ -1,4 +1,4 @@
-easy-align.txt	easy-align	Last change: December 14 2014
+*easy-align.txt*	easy-align	Last change: December 14 2014
 EASY-ALIGN - TABLE OF CONTENTS             *easyalign* *easy-align* *easy-align-toc*
 ==============================================================================
 


### PR DESCRIPTION
The first field on the first line of a help file should be a link to the
help file name. (See :h help-writing)