### PR TITLE
Resolve syntax highlighting group in neovim/treesitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,14 +469,11 @@ function exists for this purpose, returning exactly the name of the highlight
 group that is used by the easy align plugin.
 
 ```vim
-"   The function accepts 2 arguments, line and column number.
-"   However, if the arguments are skipped or have empty values,
-"   line / column number under the cursor are used instead.
-"   The function returns a table containing the position and
-"   the highlight group name.
+" Highlight group name of the cursor position
 echo easy_align#get_highlight_group_name()
-echo easy_align#get_highlight_group_name(10)
-echo easy_align#get_highlight_group_name(10, 10)
+
+" Highlight group name of the line 10, column 20
+echo easy_align#get_highlight_group_name(10, 20)
 ```
 
 ### Ignoring unmatched lines

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ highlighted as code comments or strings are ignored.
 ```vim
 " Default:
 "   If a delimiter is in a highlight group whose name matches
-"   any of the followings, it will be ignored.
+"   any of the following regular expressions, it will be ignored.
 let g:easy_align_ignore_groups = ['Comment', 'String']
 ```
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,22 @@ If a pattern in `ignore_groups` is prepended by a `!`, it will have the opposite
 meaning. For instance, if `ignore_groups` is given as `['!Comment']`, delimiters
 that are *not* highlighted as Comment will be ignored during the alignment.
 
+To make `ignore_groups` work, and to debug the related issues, it is useful to
+know which highlight group a certain location in a file belongs to. A special
+function exists for this purpose, returning exactly the name of the highlight
+group that is used by the easy align plugin.
+
+```vim
+"   The function accepts 2 arguments, line and column number.
+"   However, if the arguments are skipped or have empty values,
+"   line / column number under the cursor are used instead.
+"   The function returns a table containing the position and
+"   the highlight group name.
+echo easy_align#get_highlight_group_name()
+echo easy_align#get_highlight_group_name(10)
+echo easy_align#get_highlight_group_name(10, 10)
+```
+
 ### Ignoring unmatched lines
 
 `ignore_unmatched` option determines how EasyAlign command processes lines that

--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -92,6 +92,13 @@ endfunction
 function! s:get_highlight_group_name(line, col)
   let hl = synIDattr(synID(a:line, a:col, 0), 'name')
 
+  if hl == '' && has('nvim-0.9.0')
+    let insp = luaeval('vim.inspect_pos and vim.inspect_pos( nil, ' .. (a:line-1) .. ', ' .. (a:col-1) .. ' ) or { treesitter = {} }')
+    if !empty(insp.treesitter)
+      let hl = insp.treesitter[0].hl_group_link
+    endif
+  endif
+
   " and, finally
   return hl
 endfunction

--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -1169,3 +1169,4 @@ endfunction
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
+" vim: set et sw=2 :

--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -104,12 +104,10 @@ function! s:get_highlight_group_name(line, col)
 endfunction
 
 function! easy_align#get_highlight_group_name(...)
-  let l  = a:0 >= 1 ? a:1       : ''
-  let l  = l == ''  ? line('.') : l
-  let c  = a:0 >= 2 ? a:2       : ''
-  let c  = c == ''  ? col('.')  : c
+  let l  = get(a:, 1, line('.'))
+  let c  = get(a:, 2, col('.'))
   let hl = s:get_highlight_group_name(l, c)
-  return { 'Line': l, 'Column': c, 'HL Group': hl }
+  return { 'line': l, 'column': c, 'group': hl }
 endfunction
 
 function! s:highlighted_as(line, col, groups)

--- a/autoload/easy_align.vim
+++ b/autoload/easy_align.vim
@@ -89,9 +89,25 @@ function! s:floor2(v)
   return a:v % 2 == 0 ? a:v : a:v - 1
 endfunction
 
+function! s:get_highlight_group_name(line, col)
+  let hl = synIDattr(synID(a:line, a:col, 0), 'name')
+
+  " and, finally
+  return hl
+endfunction
+
+function! easy_align#get_highlight_group_name(...)
+  let l  = a:0 >= 1 ? a:1       : ''
+  let l  = l == ''  ? line('.') : l
+  let c  = a:0 >= 2 ? a:2       : ''
+  let c  = c == ''  ? col('.')  : c
+  let hl = s:get_highlight_group_name(l, c)
+  return { 'Line': l, 'Column': c, 'HL Group': hl }
+endfunction
+
 function! s:highlighted_as(line, col, groups)
   if empty(a:groups) | return 0 | endif
-  let hl = synIDattr(synID(a:line, a:col, 0), 'name')
+  let hl = s:get_highlight_group_name(a:line, a:col)
   for grp in a:groups
     if grp[0] == '!'
       if hl !~# grp[1:-1]

--- a/doc/easy_align.txt
+++ b/doc/easy_align.txt
@@ -567,6 +567,20 @@ opposite meaning. For instance, if `ignore_groups` is given as `['!Comment']`,
 delimiters that are not highlighted as Comment will be ignored during the
 alignment.
 
+To make `ignore_groups` work, and to debug the related issues, it is useful to
+know which highlight group a certain location in a file belongs to. A special
+function exists for this purpose, returning exactly the name of the highlight
+group that is used by the easy align plugin.
+>
+    "   The function accepts 2 arguments, line and column number.
+    "   However, if the arguments are skipped or have empty values,
+    "   line / column number under the cursor are used instead.
+    "   The function returns a table containing the position and
+    "   the highlight group name.
+    echo easy_align#get_highlight_group_name()
+    echo easy_align#get_highlight_group_name(10)
+    echo easy_align#get_highlight_group_name(10, 10)
+<
 
 < Ignoring unmatched lines >__________________________________________________~
                                            *easy-align-ignoring-unmatched-lines*

--- a/doc/easy_align.txt
+++ b/doc/easy_align.txt
@@ -517,7 +517,7 @@ highlighted as code comments or strings are ignored.
 >
     " Default:
     "   If a delimiter is in a highlight group whose name matches
-    "   any of the followings, it will be ignored.
+    "   any of the following regular expressions, it will be ignored.
     let g:easy_align_ignore_groups = ['Comment', 'String']
 <
 For example, the following paragraph

--- a/doc/easy_align.txt
+++ b/doc/easy_align.txt
@@ -572,13 +572,10 @@ know which highlight group a certain location in a file belongs to. A special
 function exists for this purpose, returning exactly the name of the highlight
 group that is used by the easy align plugin.
 >
-    "   The function accepts 2 arguments, line and column number.
-    "   However, if the arguments are skipped or have empty values,
-    "   line / column number under the cursor are used instead.
-    "   The function returns a table containing the position and
-    "   the highlight group name.
+    " Highlight group name of the cursor position
     echo easy_align#get_highlight_group_name()
-    echo easy_align#get_highlight_group_name(10)
+
+    " Highlight group name of the line 10, column 10
     echo easy_align#get_highlight_group_name(10, 10)
 <
 

--- a/doc/easy_align.txt
+++ b/doc/easy_align.txt
@@ -575,8 +575,8 @@ group that is used by the easy align plugin.
     " Highlight group name of the cursor position
     echo easy_align#get_highlight_group_name()
 
-    " Highlight group name of the line 10, column 10
-    echo easy_align#get_highlight_group_name(10, 10)
+    " Highlight group name of the line 10, column 20
+    echo easy_align#get_highlight_group_name(10, 20)
 <
 
 < Ignoring unmatched lines >__________________________________________________~

--- a/plugin/easy_align.vim
+++ b/plugin/easy_align.vim
@@ -140,3 +140,4 @@ vnoremap <silent> <Plug>(EasyAlignRepeat) :<C-U>call <SID>repeat_in_visual()<Ent
 " Backward-compatibility (deprecated)
 nnoremap <silent> <Plug>(EasyAlignOperator) :set opfunc=<SID>easy_align_op<Enter>g@
 
+" vim: set et sw=2 :


### PR DESCRIPTION
As the SUBJ says, it should now detect the highlighting group even when the syntax highlighting is managed by treesitter in neovim. This should partially address #159 

Also, I moved the highlighting detection logic into a separate function, and added end-user interface for it - now it is possible to detect the highlighting group name (or the absence of such) for any position in a file. This possibility exists as vim function only - I deliberately decided against creating command binding for it. This is a debug functionality, I'd rather prefer it not to show up in command completion.